### PR TITLE
disable mTLS

### DIFF
--- a/modules/installation/istio/config/istio-demo-auth.yaml
+++ b/modules/installation/istio/config/istio-demo-auth.yaml
@@ -13913,11 +13913,7 @@ metadata:
     istio: citadel	
 data:	
   custom-resources.yaml: |-    
-    # These policy and destination rules effectively enable mTLS for all services in the mesh. For now,
-    # they are added to Istio installation yaml for backward compatible. In future, they should be in
-    # a separated yaml file so that customer can enable mTLS independent from installation.
-    
-    # Authentication policy to enable mutual TLS for all services (that have sidecar) in the mesh.
+    # Authentication policy to enable permissive mode for all services (that have sidecar) in the mesh.
     apiVersion: "authentication.istio.io/v1alpha1"
     kind: "MeshPolicy"
     metadata:
@@ -13929,43 +13925,8 @@ data:
         release: istio
     spec:
       peers:
-      - mtls: {}
-    ---
-    # Corresponding destination rule to configure client side to use mutual TLS when talking to
-    # any service (host) in the mesh.
-    apiVersion: networking.istio.io/v1alpha3
-    kind: DestinationRule
-    metadata:
-      name: "default"
-      namespace: istio-system
-      labels:
-        app: security
-        chart: security
-        heritage: Tiller
-        release: istio
-    spec:
-      host: "*.local"
-      trafficPolicy:
-        tls:
-          mode: ISTIO_MUTUAL
-    ---
-    # Destination rule to disable (m)TLS when talking to API server, as API server doesn't have sidecar.
-    # Customer should add similar destination rules for other services that dont' have sidecar.
-    apiVersion: networking.istio.io/v1alpha3
-    kind: DestinationRule
-    metadata:
-      name: "api-server"
-      namespace: istio-system
-      labels:
-        app: security
-        chart: security
-        heritage: Tiller
-        release: istio
-    spec:
-      host: "kubernetes.default.svc.cluster.local"
-      trafficPolicy:
-        tls:
-          mode: DISABLE	
+      - mtls:
+          mode: PERMISSIVE	
   run.sh: |-    
     #!/bin/sh
     


### PR DESCRIPTION
Generated from Istio 1.1.0 with control plane mTLS enabled but service-to-service mTLS not enforced.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>