### PR TITLE
Custom app selector for each mongo instance and change ports to be just 'mongo'

### DIFF
--- a/modules/installation/app/config/account-v1.yaml
+++ b/modules/installation/app/config/account-v1.yaml
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: account-mongodb
   labels:
-    app: mongodb
+    app: account-mongodb
     chart: mongodb-5.3.2
     release: "account"
     heritage: "Tiller"
@@ -29,9 +29,9 @@ spec:
   ports:
   - name: mongo
     port: 27017
-    targetPort: mongodb
+    targetPort: mongo
   selector:
-    app: mongodb
+    app: account-mongodb
     release: "account"
 
 ---
@@ -60,19 +60,19 @@ kind: Deployment
 metadata:
   name: account-mongodb
   labels:
-    app: mongodb
+    app: account-mongodb
     chart: mongodb-5.3.2
     release: "account"
     heritage: "Tiller"
 spec:
   selector:
     matchLabels:
-      app: mongodb
+      app: account-mongodb
       release: "account"
   template:
     metadata:
       labels:
-        app: mongodb
+        app: account-mongodb
         release: "account"
         chart: mongodb-5.3.2
     spec:
@@ -89,7 +89,7 @@ spec:
         - name: MONGODB_ENABLE_IPV6
           value: "yes"
         ports:
-        - name: mongodb
+        - name: mongo
           containerPort: 27017
         livenessProbe:
           exec:

--- a/modules/installation/app/config/transaction-log-v1.yaml
+++ b/modules/installation/app/config/transaction-log-v1.yaml
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: transaction-log-mongodb
   labels:
-    app: mongodb
+    app: transaction-log-mongodb
     chart: mongodb-5.3.2
     release: "transaction-log"
     heritage: "Tiller"
@@ -29,9 +29,9 @@ spec:
   ports:
   - name: mongo
     port: 27017
-    targetPort: mongodb
+    targetPort: mongo
   selector:
-    app: mongodb
+    app: transaction-log-mongodb
     release: "transaction-log"
 
 ---
@@ -60,19 +60,19 @@ kind: Deployment
 metadata:
   name: transaction-log-mongodb
   labels:
-    app: mongodb
+    app: transaction-log-mongodb
     chart: mongodb-5.3.2
     release: "transaction-log"
     heritage: "Tiller"
 spec:
   selector:
     matchLabels:
-      app: mongodb
+      app: transaction-log-mongodb
       release: "transaction-log"
   template:
     metadata:
       labels:
-        app: mongodb
+        app: transaction-log-mongodb
         release: "transaction-log"
         chart: mongodb-5.3.2
     spec:
@@ -89,7 +89,7 @@ spec:
         - name: MONGODB_ENABLE_IPV6
           value: "yes"
         ports:
-        - name: mongodb
+        - name: mongo
           containerPort: 27017
         livenessProbe:
           exec:

--- a/modules/installation/app/config/user-v1.yaml
+++ b/modules/installation/app/config/user-v1.yaml
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: user-mongodb
   labels:
-    app: mongodb
+    app: user-mongodb
     chart: mongodb-5.3.2
     release: "user"
     heritage: "Tiller"
@@ -29,9 +29,9 @@ spec:
   ports:
   - name: mongo
     port: 27017
-    targetPort: mongodb
+    targetPort: mongo
   selector:
-    app: mongodb
+    app: user-mongodb
     release: "user"
 
 ---
@@ -60,19 +60,19 @@ kind: Deployment
 metadata:
   name: user-mongodb
   labels:
-    app: mongodb
+    app: user-mongodb
     chart: mongodb-5.3.2
     release: "user"
     heritage: "Tiller"
 spec:
   selector:
     matchLabels:
-      app: mongodb
+      app: user-mongodb
       release: "user"
   template:
     metadata:
       labels:
-        app: mongodb
+        app: user-mongodb
         release: "user"
         chart: mongodb-5.3.2
     spec:
@@ -89,7 +89,7 @@ spec:
         - name: MONGODB_ENABLE_IPV6
           value: "yes"
         ports:
-        - name: mongodb
+        - name: mongo
           containerPort: 27017
         livenessProbe:
           exec:

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/deployment-standalone.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/deployment-standalone.yaml
@@ -109,7 +109,7 @@ spec:
           value: {{ .Values.mongodbExtraFlags | join " " }}
         {{- end }}
         ports:
-        - name: mongodb
+        - name: mongo
           containerPort: 27017
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/headless-svc-rs.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/headless-svc-rs.yaml
@@ -16,7 +16,7 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
-  - name: mongodb
+  - name: mongo
     port: {{ .Values.service.port }}
 {{- if .Values.metrics.enabled }}
   - name: metrics

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/statefulset-arbiter-rs.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/statefulset-arbiter-rs.yaml
@@ -63,7 +63,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: {{ .Values.service.port }}
-            name: mongodb
+            name: mongo
           env:
           {{- if .Values.image.debug}}
           - name: NAMI_DEBUG
@@ -116,7 +116,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
-              port: mongodb
+              port: mongo
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -126,7 +126,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: mongodb
+              port: mongo
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/statefulset-primary-rs.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/statefulset-primary-rs.yaml
@@ -68,7 +68,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: {{ .Values.service.port }}
-            name: mongodb
+            name: mongo
           env:
           {{- if .Values.image.debug}}
           - name: NAMI_DEBUG

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/statefulset-secondary-rs.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/statefulset-secondary-rs.yaml
@@ -69,7 +69,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - containerPort: {{ .Values.service.port }}
-            name: mongodb
+            name: mongo
           env:
           {{- if .Values.image.debug}}
           - name: NAMI_DEBUG

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/svc-primary-rs.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/svc-primary-rs.yaml
@@ -18,9 +18,9 @@ spec:
    clusterIP: {{ .Values.service.clusterIP }}
    {{- end }}
   ports:
-  - name: mongodb
+  - name: mongo
     port: 27017
-    targetPort: mongodb
+    targetPort: mongo
 {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/samples/modernbank/kubernetes/helm/mongodb/templates/svc-standalone.yaml
+++ b/samples/modernbank/kubernetes/helm/mongodb/templates/svc-standalone.yaml
@@ -20,7 +20,7 @@ spec:
   ports:
   - name: mongo
     port: 27017
-    targetPort: mongodb
+    targetPort: mongo
 {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}

--- a/samples/modernbank/kubernetes/helm/values/account-v1.yaml
+++ b/samples/modernbank/kubernetes/helm/values/account-v1.yaml
@@ -11,3 +11,5 @@ image:
 
 mongodb:
     enabled: true
+    nameOverride: account-mongodb
+    fullnameOverride: account-mongodb

--- a/samples/modernbank/kubernetes/helm/values/transaction-log-v1.yaml
+++ b/samples/modernbank/kubernetes/helm/values/transaction-log-v1.yaml
@@ -11,3 +11,5 @@ image:
 
 mongodb:
     enabled: true
+    nameOverride: transaction-log-mongodb
+    fullnameOverride: transaction-log-mongodb

--- a/samples/modernbank/kubernetes/helm/values/user-v1.yaml
+++ b/samples/modernbank/kubernetes/helm/values/user-v1.yaml
@@ -11,3 +11,5 @@ image:
 
 mongodb:
     enabled: true
+    nameOverride: user-mongodb
+    fullnameOverride: user-mongodb


### PR DESCRIPTION
Fixed app selectors so the mongo instance for each microservice points to the right mongo.
Also updated port naming in mongo services to be just 'mongo' according to: https://istio.io/docs/setup/kubernetes/prepare/requirements/