### PR TITLE
Remove MeshPolicy in favor of PeerAuthentication

### DIFF
--- a/modules/security/mtls/config/strictpolicy.yaml
+++ b/modules/security/mtls/config/strictpolicy.yaml
@@ -1,5 +1,5 @@
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
 metadata:
   name: "default"
   labels:
@@ -8,6 +8,5 @@ metadata:
     heritage: Tiller
     release: istio
 spec:
-  peers:
-  - mtls:
+  mtls:
       mode: STRICT


### PR DESCRIPTION
MeshPolicy and policy were removed in https://github.com/istio/istio/issues/22602
in favor of PeerAuthentication