### PR TITLE
[security] Use peerauthentications crd

### DIFF
--- a/modules/security/mtls/README.md
+++ b/modules/security/mtls/README.md
@@ -73,13 +73,12 @@ Apply strict policy
 
     We can verify the policy matches what we expect:
     ```
-    $ kubectl describe meshpolicy.authentication.istio.io/default
+    $ kubectl describe peerauthentication.security.istio.io/default
 
     ...
     Spec:
-      Peers:
-        Mtls:
-          Mode:  STRICT
+      Mtls:
+        Mode:  STRICT
     ```
 
 1. Run the last step in previous task to verify it no longer connects:

--- a/modules/security/mtls/config/strictpolicy.yaml
+++ b/modules/security/mtls/config/strictpolicy.yaml
@@ -1,5 +1,5 @@
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
 metadata:
   name: "default"
   labels:
@@ -8,6 +8,5 @@ metadata:
     heritage: Tiller
     release: istio
 spec:
-  peers:
-  - mtls:
-      mode: STRICT
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
meshpolicy was removed in istio 1.6.0, use
peerauthentications instead to implement strict mtls

Signed-off-by: Arko Dasgupta <arko@tetrate.io>