### PR TITLE
adds a status superseded by istio-labs repo info to top of main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### Status
+
+This repository has been superseded by https://github.com/tetrateio/istio-labs
+
 # Istio Workshop
 
 This workshop will introduce you to Istio and Envoy, service mesh tools that have changed the landscape of cloud-native applications. You will learn how and why to use these tools to solve the challenges of observability, security, networking, and multi-cloud deployments.


### PR DESCRIPTION
hi liam,

afaict this repository has been superseded by https://github.com/tetrateio/istio-labs

i'd like to put that information into the readme for this repository _and_ also request that this repository be archived, to prevent any future confusion.

thanks! / eitan